### PR TITLE
Add support for terraform language server completion

### DIFF
--- a/containers/devcrate-cloud/Dockerfile
+++ b/containers/devcrate-cloud/Dockerfile
@@ -25,7 +25,14 @@ RUN pip3 install --no-cache-dir --user wheel awscli
 RUN TF_VERSION=$(curl --silent "https://api.github.com/repos/hashicorp/terraform/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")' | cut -c 2-) \
     && wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip \
     && sudo unzip -d /usr/local/bin/ terraform_${TF_VERSION}_linux_amd64.zip \ 
-    && rm  terraform_${TF_VERSION}_linux_amd64.zip
+    && rm terraform_${TF_VERSION}_linux_amd64.zip
+
+# terraform - language server for commpletion.
+# .[1:] - remove prefix 'v' from version tag.
+RUN TF_LS_VERSION=$(curl --silent "https://api.github.com/repos/hashicorp/terraform-ls/releases/latest" | jq -r ".tag_name | .[1:]")
+    && wget http://releases.hashicorp.com/terraform-ls/${TF_LS_VERSION}/terraform-ls_${TF_LS_VERSION}_linux_amd64.zip \
+    && sudo unzip -d /usr/local/bin/ terraform-ls_${TF_LS_VERSION}_linux_amd64.zip \
+    && rm terraform-ls_${TF_LS_VERSION}_linux_amd64.zip
 
 # helm
 RUN curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash

--- a/containers/devcrate-cloud/Dockerfile
+++ b/containers/devcrate-cloud/Dockerfile
@@ -29,7 +29,7 @@ RUN TF_VERSION=$(curl --silent "https://api.github.com/repos/hashicorp/terraform
 
 # terraform - language server for commpletion.
 # .[1:] - remove prefix 'v' from version tag.
-RUN TF_LS_VERSION=$(curl --silent "https://api.github.com/repos/hashicorp/terraform-ls/releases/latest" | jq -r ".tag_name | .[1:]")
+RUN TF_LS_VERSION=$(curl --silent "https://api.github.com/repos/hashicorp/terraform-ls/releases/latest" | jq -r ".tag_name | .[1:]") \
     && wget http://releases.hashicorp.com/terraform-ls/${TF_LS_VERSION}/terraform-ls_${TF_LS_VERSION}_linux_amd64.zip \
     && sudo unzip -d /usr/local/bin/ terraform-ls_${TF_LS_VERSION}_linux_amd64.zip \
     && rm terraform-ls_${TF_LS_VERSION}_linux_amd64.zip

--- a/dotfiles/base/nvim/coc-settings.json
+++ b/dotfiles/base/nvim/coc-settings.json
@@ -33,8 +33,7 @@
     "https://kubernetesjsonschema.dev/v1.14.0/deployment-apps-v1.json": "/*.yml",
     "https://kubernetesjsonschema.dev/v1.10.3-standalone/service-v1.json": "/*.yml"
   },
-  // java
-  // disable autobuild due to high cpu consumpution.
+  // java - disable autobuild due to high cpu consumpution.
   "java.autobuild.enabled": false,
   // scala - disable to prevent scala langserver from running when developing java.
   "metals.enable": false,
@@ -49,6 +48,19 @@
            "directory": ".ccls-cache"
         }
       }
+    },
+    // terraform
+    "terraform": {
+      "command": "terraform-ls",
+      "args": ["serve"],
+      "filetypes": [
+        "terraform",
+        "tf"
+      ],
+      "initializationOptions": {},
+      "settings": {}
     }
   }
+
+ 
 }


### PR DESCRIPTION
- Add [terraform-ls](https://github.com/hashicorp/terraform-ls) to devcrate-cloud image.
- Configure neovim's coc.nvim to use `terraform-ls` for completion.