### PR TITLE
Bump Node.js bundled devcrate images to Node.js 14 LTS

### DIFF
--- a/containers/devcrate/Dockerfile
+++ b/containers/devcrate/Dockerfile
@@ -25,7 +25,7 @@ RUN sed -i -e 's/# en_SG.UTF-8 UTF-8/en_SG.UTF-8 UTF-8/' /etc/locale.gen && \
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
     && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" \
     && add-apt-repository ppa:neovim-ppa/stable \
-    && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+    && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && add-apt-repository ppa:hnakamur/universal-ctags
 
 ## install tools


### PR DESCRIPTION
### Motivation
Resolves #7 

### This PR
Bumps Node.js used in devcrate to Node 14 LTS