### PR TITLE
nvim: Add rust completion support via coc-rls extension

### DIFF
--- a/dotfiles/base/nvim_plugin/completion/engine.vim
+++ b/dotfiles/base/nvim_plugin/completion/engine.vim
@@ -4,6 +4,8 @@
 " NeoVim Configuration
 "
 
+source ~/.config/nvim_plugin/completion/language.vim
+
 "" editing
 "check current character is a utility
 function! s:CheckBackspace() abort
@@ -16,21 +18,12 @@ function! BootstrapCOC(info)
     if a:info.status == 'installed' || a:info.force
         echo 'bootstrapping coc'
         call coc#util#install()
-
-        " basic completion sources
-        echo 'setting up basic completion sources '
-        CocInstall -sync coc-tag coc-syntax coc-ultisnips
-
+        call InstallCOCExtensions()
         call DeployLangSupport(g:lang_support_config)
     endif
 endfunction
 
-" completion engine
 Plug 'neoclide/coc.nvim', {'branch': 'release', 'do': function('BootstrapCOC')}
-" core sources
-Plug 'neoclide/coc-yaml', {'do': 'yarn install --frozen-lockfile'}
-Plug 'neoclide/coc-json', {'do': 'yarn install --frozen-lockfile'}
-Plug 'neoclide/coc-html', {'do': 'yarn install --frozen-lockfile'}
 
 " function text object
 xmap if <Plug>(coc-funcobj-i)

--- a/dotfiles/base/nvim_plugin/completion/language/c_cpp_objc.vim
+++ b/dotfiles/base/nvim_plugin/completion/language/c_cpp_objc.vim
@@ -7,6 +7,10 @@
 " BuildClangLangServer() - builds c/c++/obj-c language sever
 " prerequisites - cmake>=3.8, clang, clang-7 libclang-dev
 function! BuildClangLangServer() abort
+    if executable('/usr/local/bin/ccls')
+        " ccls already installed nothing to do
+        return
+    endif
     " setup work directory
     let l:work_dir = '/tmp/clang_ls'
     exec 'silent !mkdir -p ' . l:work_dir

--- a/dotfiles/base/nvim_plugin/completion/language/coc_native.vim
+++ b/dotfiles/base/nvim_plugin/completion/language/coc_native.vim
@@ -6,42 +6,46 @@
 "
 
 function! InstallCOCExtensions()
-    " core completion sources
-    CocInstall -sync coc-tag coc-syntax coc-ultisnips coc-yaml coc-json coc-html
+    " core completion extensions
+    let extensions = [
+        \'coc-tag', 'coc-syntax', 'coc-ultisnips', 'coc-yaml', 'coc-json', 'coc-html'
+        \]
 
     " deploy only if explicit specified in <LANG>_ENABLE env var
     "js/ts
     if ! $IS_DEVCRATE || $JS_ENABLE == '1'
-        CocInstall -sync coc-tsserver
+        call add(extensions, 'coc-tsserver')
     endif
 
     "java
     if ! $IS_DEVCRATE || $JAVA_ENABLE == '1'
-        CocInstall -sync coc-java
+        call add(extensions, 'coc-java')
     endif
 
     "python
     if ! $IS_DEVCRATE || $PYTHON_ENABLE == '1'
-        CocInstall -sync coc-pyright
+        call add(extensions, 'coc-pyright')
     endif
 
     "csharp
     if ! $IS_DEVCRATE || $CSHARP_ENABLE == '1'
-        CocInstall -sync coc-omnisharp
+        call add(extensions, 'coc-omnisharp')
     endif
 
     "scala
     if ! $IS_DEVCRATE || $SCALA_ENABLE == '1'
-        CocInstall -sync coc-metals
+        call add(extensions, 'coc-metals')
     endif
 
     "golang
     if ! $IS_DEVCRATE || $GO_ENABLE == '1'
-        CocInstall -sync coc-go
+        call add(extensions, 'coc-go')
     endif
 
     "rust
     if ! $IS_DEVCRATE || $GO_ENABLE == '1'
-        CocInstall -sync coc-rls
+        call add(extensions, 'coc-rls')
     endif
+
+    execute 'CocInstall -sync ' . join(extensions, ' ')
 endfunction

--- a/dotfiles/base/nvim_plugin/completion/language/coc_native.vim
+++ b/dotfiles/base/nvim_plugin/completion/language/coc_native.vim
@@ -5,38 +5,43 @@
 " NeoVim Configuration
 "
 
-" devcrate - deploy only if explicit specified in <LANG>_ENABLE env var
-"js/ts
-if ! $IS_DEVCRATE || $JS_ENABLE == '1'
-    Plug 'neoclide/coc-tsserver', {'tag': '1.3.7', 'do': 'yarn install --frozen-lockfile'}
-endif
+function! InstallCOCExtensions()
+    " core completion sources
+    CocInstall -sync coc-tag coc-syntax coc-ultisnips coc-yaml coc-json coc-html
 
-"java
-if ! $IS_DEVCRATE || $JAVA_ENABLE == '1'
-    Plug 'neoclide/coc-java', {'do': 'yarn install --frozen-lockfile'}
-endif
+    " deploy only if explicit specified in <LANG>_ENABLE env var
+    "js/ts
+    if ! $IS_DEVCRATE || $JS_ENABLE == '1'
+        CocInstall -sync coc-tsserver
+    endif
 
-"python
-if ! $IS_DEVCRATE || $PYTHON_ENABLE == '1'
-    Plug 'fannheyward/coc-pyright', {'do': 'yarn install --frozen-lockfile'}
-endif
+    "java
+    if ! $IS_DEVCRATE || $JAVA_ENABLE == '1'
+        CocInstall -sync coc-java
+    endif
 
-"csharp
-if ! $IS_DEVCRATE || $CSHARP_ENABLE == '1'
-    Plug 'coc-extensions/coc-omnisharp', {'do': 'yarn install --frozen-lockfile'}
-endif
+    "python
+    if ! $IS_DEVCRATE || $PYTHON_ENABLE == '1'
+        CocInstall -sync coc-pyright
+    endif
 
-"scala
-if ! $IS_DEVCRATE || $SCALA_ENABLE == '1'
-    Plug 'scalameta/coc-metals', {'do': 'yarn install --frozen-lockfile'}
-endif
+    "csharp
+    if ! $IS_DEVCRATE || $CSHARP_ENABLE == '1'
+        CocInstall -sync coc-omnisharp
+    endif
 
-"golang
-if ! $IS_DEVCRATE || $GO_ENABLE == '1'
-    Plug 'josa42/coc-go', {'do': 'yarn install --frozen-locklife'}
-endif
+    "scala
+    if ! $IS_DEVCRATE || $SCALA_ENABLE == '1'
+        CocInstall -sync coc-metals
+    endif
 
-"rust
-if ! $IS_DEVCRATE || $GO_ENABLE == '1'
-    Plug 'neoclide/coc-rls', {'do': 'yarn install --frozen-locklife'}
-endif
+    "golang
+    if ! $IS_DEVCRATE || $GO_ENABLE == '1'
+        CocInstall -sync coc-go
+    endif
+
+    "rust
+    if ! $IS_DEVCRATE || $GO_ENABLE == '1'
+        CocInstall -sync coc-rls
+    endif
+endfunction

--- a/dotfiles/base/nvim_plugin/completion/language/coc_native.vim
+++ b/dotfiles/base/nvim_plugin/completion/language/coc_native.vim
@@ -35,3 +35,8 @@ endif
 if ! $IS_DEVCRATE || $GO_ENABLE == '1'
     Plug 'josa42/coc-go', {'do': 'yarn install --frozen-locklife'}
 endif
+
+"rust
+if ! $IS_DEVCRATE || $GO_ENABLE == '1'
+    Plug 'neoclide/coc-rls', {'do': 'yarn install --frozen-locklife'}
+endif


### PR DESCRIPTION
### Motivation
Add rust completion support to neovim via [coc-rls](https://github.com/neoclide/coc-rls) coc-extensions

### This PR 
- Adds coc-rls extensions to bring rust completion support.
- Refactor to install all coc-extensions via `:CocInstall` commands

> Refactor is required as coc-rls does not install properly with vim-plug & `yarn install --frozen-lockfile`
> Due to unresolved issues with coc-rls's use of npm-run-all.
